### PR TITLE
Change turnstile.rs to use enums instead of consts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 regex
 turnstile
+
+regex.exe
+regex.pdb
+turnstile.exe
+turnstile.pdb

--- a/turnstile.rs
+++ b/turnstile.rs
@@ -1,53 +1,51 @@
 use std::io::{self, BufRead, Write};
 
+// `#[repr(usize)]` allows us to convert `State` varients into a `usize` based
+// on it's index in the `State` enum using `<State> as usize`
+#[derive(Debug, Clone, Copy)]
+#[repr(usize)]
 enum State {
-    Locked,
-    Unlocked,
+    Locked,   // 0
+    Unlocked, // 1
+    #[doc(hidden)]
+    COUNT,    // 2 (quick and easy way to do this)
 }
 
-const LOCKED: usize = 0;
-const UNLOCKED: usize = 1;
-const STATES_COUNT: usize = 2;
+#[derive(Debug, Clone, Copy)]
+#[repr(usize)]
+enum Event {
+    Push,  // 0
+    Coin,  // 1
+    #[doc(hidden)]
+    COUNT, // 2
+}
 
-const PUSH: usize = 0;
-const COIN: usize = 1;
-const EVENTS_COUNT: usize = 2;
-
-const FSM: [[usize; EVENTS_COUNT]; STATES_COUNT] = [
-  // PUSH    COIN
-    [LOCKED, UNLOCKED],        // LOCKED
-    [LOCKED, UNLOCKED],        // UNLOCKED
+const FSM: [[State; Event::COUNT as usize]; State::COUNT as usize] = [
+//   Event::Push    Event::Coin
+    [State::Locked, State::Unlocked], // State::Locked
+    [State::Locked, State::Unlocked], // State::Unlocked
 ];
 
-fn next_state(state: usize, event: usize) -> usize {
-    FSM[state][event]
-}
-
-fn state_to_str(state: usize) -> &'static str {
-    match state {
-        LOCKED => "Locked",
-        UNLOCKED => "Unlocked",
-        _ => unreachable!()
-    }
+fn next_state(state: State, event: Event) -> State {
+    FSM[state as usize][event as usize]
 }
 
 fn main() {
-    let mut state = LOCKED;
+    let mut state = State::Locked;
 
-    println!("State: {}", state_to_str(state));
+    println!("State: {:?}", state);
     print!("> ");
     io::stdout().flush().unwrap();
+
     for line in io::stdin().lock().lines() {
         match line.unwrap().as_str() {
-            "coin" => state = next_state(state, COIN),
-            "push" => state = next_state(state, PUSH),
-            "quit" => return,
-            unknown => {
-                eprintln!("ERROR: Unknown event {}", unknown);
-            }
+            "coin" => state = next_state(state, Event::Coin),
+            "push" => state = next_state(state, Event::Push),
+            "quit" => break,
+            unknown => eprintln!("ERROR: Unknown event {}", unknown),
         }
 
-        println!("State: {}", state_to_str(state));
+        println!("State: {:?}", state);
         print!("> ");
         io::stdout().flush().unwrap();
     }


### PR DESCRIPTION
I was watching [the stream] and saw that you couldn't find how to use an `enum` for the `State` and `Event`, so here is that implemented without any external crates.

**It's simple, just not very intuitive; *which is a shame*.**

Anyway, thanks for the interesting stream, I'm going to watch the rest now.

[the stream]: https://www.youtube.com/watch?v=MH56D5M9xSQ&t=2338s

**Edit**:

I realise now after making this PR that it would have been better to add it as a separate file; that way the original would still exist for reference. I can do this if you would like me to?