### PR TITLE
use traits for display and add indexing by enums in turnstile.rs

### DIFF
--- a/turnstile.rs
+++ b/turnstile.rs
@@ -52,7 +52,7 @@ fn next_state(state: State, event: Event) -> State {
 fn main() {
     let mut state = State::Locked;
 
-    println!("State: {}", state.to_string());
+    println!("State: {}", state);
     print!("> ");
     io::stdout().flush().unwrap();
     for line in io::stdin().lock().lines() {
@@ -65,7 +65,7 @@ fn main() {
             }
         }
 
-        println!("State: {}", state.to_string());
+        println!("State: {}", state);
         print!("> ");
         io::stdout().flush().unwrap();
     }

--- a/turnstile.rs
+++ b/turnstile.rs
@@ -1,53 +1,71 @@
+#![feature(variant_count)]
+use std::{fmt::{self, Display}, ops::Index, io::{Write, BufRead}};
 use std::io::{self, BufRead, Write};
 
+#[derive(Copy, Clone)]
 enum State {
-    Locked,
-    Unlocked,
+    Locked = 0,
+    Unlocked = 1,
 }
 
-const LOCKED: usize = 0;
-const UNLOCKED: usize = 1;
-const STATES_COUNT: usize = 2;
-
-const PUSH: usize = 0;
-const COIN: usize = 1;
-const EVENTS_COUNT: usize = 2;
-
-const FSM: [[usize; EVENTS_COUNT]; STATES_COUNT] = [
-  // PUSH    COIN
-    [LOCKED, UNLOCKED],        // LOCKED
-    [LOCKED, UNLOCKED],        // UNLOCKED
-];
-
-fn next_state(state: usize, event: usize) -> usize {
-    FSM[state][event]
+impl Display for State {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+			match &self {
+				State::Locked => write!(f, "Locked"),
+				State::Unlocked => write!(f, "Unlocked")
+			}
+	}
 }
+impl<T, const N: usize> Index<State> for [T; N] {
+    type Output = T;
 
-fn state_to_str(state: usize) -> &'static str {
-    match state {
-        LOCKED => "Locked",
-        UNLOCKED => "Unlocked",
-        _ => unreachable!()
+    fn index(&self, index: State) -> &Self::Output {
+        &self[index as usize]
     }
 }
 
-fn main() {
-    let mut state = LOCKED;
+enum Event {
+	Push = 0,
+	Coin = 1,
+}
+impl<T, const N: usize> Index<Event> for [T; N] {
+    type Output = T;
 
-    println!("State: {}", state_to_str(state));
+    fn index(&self, index: Event) -> &Self::Output {
+        &self[index as usize]
+    }
+}
+const EVENTS_COUNT: usize = std::mem::variant_count::<Event>();
+const STATES_COUNT: usize = std::mem::variant_count::<State>();
+const FSM: [[State; EVENTS_COUNT]; STATES_COUNT] = [
+  // PUSH    COIN
+    [State::Locked, State::Unlocked],        // LOCKED
+    [State::Locked, State::Unlocked],        // UNLOCKED
+];
+
+
+
+fn next_state(state: State, event: Event) -> State {
+    FSM[state][event]
+}
+
+fn main() {
+    let mut state = State::Locked;
+
+    println!("State: {}", state.to_string());
     print!("> ");
     io::stdout().flush().unwrap();
     for line in io::stdin().lock().lines() {
         match line.unwrap().as_str() {
-            "coin" => state = next_state(state, COIN),
-            "push" => state = next_state(state, PUSH),
+            "coin" => state = next_state(state, Event::Coin),
+            "push" => state = next_state(state, Event::Push),
             "quit" => return,
             unknown => {
                 eprintln!("ERROR: Unknown event {}", unknown);
             }
         }
 
-        println!("State: {}", state_to_str(state));
+        println!("State: {}", state.to_string());
         print!("> ");
         io::stdout().flush().unwrap();
     }

--- a/turnstile.rs
+++ b/turnstile.rs
@@ -1,5 +1,5 @@
 #![feature(variant_count)]
-use std::{fmt::{self, Display}, ops::Index, io::{Write, BufRead}};
+use std::{fmt::{self, Display}, ops::Index};
 use std::io::{self, BufRead, Write};
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
This code:
- Enables a new unstable feature `variant_count` (just for fun)
- Switches out const usizes to enum instead
- impls `Index<State>` and `Index<Event>` for State and Event enums
- uses display trait for converting enum to string